### PR TITLE
Updating falcon-7b with falcon-7b-instruct and StoppingCriteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🤖 Prem Services
 
-## Contributing 
+## Contributing
 
 Each folder represents one or more Prem services. All the current services have been built with Python and FastAPI. In order to create a new service you need to create a new folder or extend an existing one.
 

--- a/cht-falcon/models.py
+++ b/cht-falcon/models.py
@@ -4,6 +4,7 @@ from typing import List
 
 import torch
 from transformers import AutoTokenizer, Pipeline, pipeline
+from utils import FalconStoppingCriteria
 
 
 class ChatModel(ABC):
@@ -32,6 +33,7 @@ class ChatModel(ABC):
 
 class FalconBasedModel(ChatModel):
     model = None
+    stopping_criteria = None
 
     @classmethod
     def generate(
@@ -41,7 +43,7 @@ class FalconBasedModel(ChatModel):
         top_p: float = 0.9,
         n: int = 1,
         stream: bool = False,
-        max_tokens: int = 128,
+        max_tokens: int = 256,
         stop: str = "",
         **kwargs,
     ) -> List:
@@ -50,8 +52,14 @@ class FalconBasedModel(ChatModel):
             cls.model(
                 message,
                 max_length=max_tokens,
-                num_return_sequences=1,
+                num_return_sequences=n,
+                temperature=temperature,
+                top_p=top_p,
                 eos_token_id=cls.tokenizer.eos_token_id,
+                return_full_text=kwargs.get("return_full_text", False),
+                do_sample=kwargs.get("do_sample", True),
+                stop_sequence=stop[0] if stop else None,
+                stopping_criteria=cls.stopping_criteria(stop, message, cls.tokenizer),
             )[0]["generated_text"]
         ]
 
@@ -59,14 +67,15 @@ class FalconBasedModel(ChatModel):
     def get_model(cls) -> Pipeline:
         if cls.model is None:
             cls.tokenizer = AutoTokenizer.from_pretrained(
-                os.getenv("MODEL_ID", "tiiuae/falcon-7b"),
+                os.getenv("MODEL_ID", "tiiuae/falcon-7b-instruct"),
                 trust_remote_code=True,
             )
             cls.model = pipeline(
                 tokenizer=cls.tokenizer,
-                model=os.getenv("MODEL_ID", "tiiuae/falcon-7b"),
+                model=os.getenv("MODEL_ID", "tiiuae/falcon-7b-instruct"),
                 torch_dtype=torch.bfloat16,
                 trust_remote_code=True,
                 device_map=os.getenv("DEVICE", "auto"),
             )
+        cls.stopping_criteria = FalconStoppingCriteria
         return cls.model

--- a/cht-falcon/routes.py
+++ b/cht-falcon/routes.py
@@ -17,7 +17,7 @@ class ChatCompletionInput(BaseModel):
     top_p: float = 1.0
     n: int = 1
     stream: bool = False
-    stop: Optional[Union[str, List[str]]] = ""
+    stop: Optional[Union[str, List[str]]] = ["\nUser:", "User:"]
     max_tokens: int = 64
     presence_penalty: float = 0.0
     frequence_penalty: float = 0.0

--- a/cht-falcon/routes.py
+++ b/cht-falcon/routes.py
@@ -17,7 +17,7 @@ class ChatCompletionInput(BaseModel):
     top_p: float = 1.0
     n: int = 1
     stream: bool = False
-    stop: Optional[Union[str, List[str]]] = ["\nUser:", "User:"]
+    stop: Optional[Union[str, List[str]]] = ["User:"]
     max_tokens: int = 64
     presence_penalty: float = 0.0
     frequence_penalty: float = 0.0

--- a/cht-falcon/routes.py
+++ b/cht-falcon/routes.py
@@ -18,7 +18,7 @@ class ChatCompletionInput(BaseModel):
     n: int = 1
     stream: bool = False
     stop: Optional[Union[str, List[str]]] = ""
-    max_tokens: int = 32
+    max_tokens: int = 64
     presence_penalty: float = 0.0
     frequence_penalty: float = 0.0
     logit_bias: Optional[dict] = {}
@@ -85,7 +85,7 @@ async def chat_completions(body: ChatCompletionInput) -> Dict[str, Any]:
             )
         return ChatCompletionResponse(
             id=str(uuid.uuid4()),
-            model=os.getenv("MODEL_ID", "tiiuae/falcon-7b"),
+            model=os.getenv("MODEL_ID", "tiiuae/falcon-7b-instruct"),
             object="chat.completion",
             created=int(dt.now().timestamp()),
             choices=[

--- a/cht-falcon/tests/test_views.py
+++ b/cht-falcon/tests/test_views.py
@@ -8,7 +8,7 @@ def test_chat_falcon() -> None:
         response = client.post(
             "/v1/chat/completions",
             json={
-                "model": "falcon-7b",
+                "model": "falcon-7b-instruct",
                 "messages": [{"role": "user", "content": "Hello!"}],
             },
         )

--- a/cht-falcon/utils.py
+++ b/cht-falcon/utils.py
@@ -1,0 +1,28 @@
+from typing import List
+
+from transformers import StoppingCriteria
+
+
+class FalconStoppingCriteria(StoppingCriteria):
+    def __init__(self, target_sequences: List[str], prompt, tokenizer) -> None:
+        self.target_sequences = target_sequences
+        self.prompt = prompt
+        self.tokenizer = tokenizer
+
+    def __call__(self, input_ids, scores, **kwargs) -> bool:
+        if not self.target_sequences:
+            return False
+        # Get the generated text as a string
+        generated_text = self.tokenizer.decode(input_ids[0])
+        generated_text = generated_text.replace(self.prompt, "")
+        # Check if the target sequence appears in the generated text
+        return any(
+            target_sequence in generated_text
+            for target_sequence in self.target_sequences
+        )
+
+    def __len__(self) -> int:
+        return len(self.target_sequences)
+
+    def __iter__(self):
+        yield self

--- a/scripts/cht_falcon.sh
+++ b/scripts/cht_falcon.sh
@@ -5,10 +5,10 @@ set -e
 export VERSION=1.0.0
 
 docker buildx build --push \
-    --cache-from ghcr.io/premai-io/chat-falcon-7b-gpu:latest \
+    --cache-from ghcr.io/premai-io/chat-falcon-7b-instruct-gpu:latest \
     --file ./cht-falcon/docker/gpu/Dockerfile \
-    --build-arg="MODEL_ID=tiiuae/falcon-7b" \
-    --tag ghcr.io/premai-io/chat-falcon-7b-gpu:latest \
-    --tag ghcr.io/premai-io/chat-falcon-7b-gpu:$VERSION \
+    --build-arg="MODEL_ID=tiiuae/falcon-7b-instruct" \
+    --tag ghcr.io/premai-io/chat-falcon-7b-instruct-gpu:latest \
+    --tag ghcr.io/premai-io/chat-falcon-7b-instruct-gpu:$VERSION \
     ./cht-falcon
-docker run --gpus all ghcr.io/premai-io/chat-falcon-7b-gpu:latest pytest
+docker run --gpus all ghcr.io/premai-io/chat-falcon-7b-instruct-gpu:latest pytest


### PR DESCRIPTION
This PR helps update falcon-7b service to use [falcon-7b-instruct](https://huggingface.co/tiiuae/falcon-7b-instruct) model instead, which is better in conversations and a finetuned version of the base model falcon-7b.

It also adds support for returning only the generated response from the model which is controllable by `return_full_text (bool)` parameter.

It adds support for StoppingCriteria based on tokens too which helps doing something like below using langchain:
```python
# stop param
LLMChain(llm=chat, prompt=prompt, verbose=True).run(user_message=user_message, stop=["\nUser:", "User:"])
```