### PR TITLE
ci: weekly test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   push: {branches: [main]}
   pull_request_target:
+  schedule: [{cron: '0 11 * * 7'}]  # M H d m w (Sun 11:00)
 jobs:
   setup:
     environment: ${{ github.event_name == 'pull_request_target' && !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association) && 'external' || 'internal' }}


### PR DESCRIPTION
Fixes [self-hosted runner auto-removal](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/removing-self-hosted-runners)

> A self-hosted runner is automatically removed from GitHub if it has not connected to GitHub Actions for more than 14 days
