### PR TITLE
ci: debug external trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     - id: list
       name: List modified models
       run: |
+        echo "debug:author_association:${{ github.event.pull_request.author_association }}"
         git diff --stat HEAD~1
         echo "modified=$(
           for model in $(ls -d *-*); do


### PR DESCRIPTION
I suspect that `github.event.pull_request.author_association` doesn't work properly if the author gets permissions indirectly via a team
